### PR TITLE
fix of redirect url for loginStyle="redirect"

### DIFF
--- a/office365_client.js
+++ b/office365_client.js
@@ -24,7 +24,7 @@ Office365.requestCredential = function(options, credentialRequestCompleteCallbac
   // The Microsoft Office 365 Application not allow the parameter "close" at redirect URLs
   const redirectUri = OAuth._redirectUri('office365', config).replace('?close', '');
 
-  const loginUrl = `https://login.microsoftonline.com/${ config.tenant || 'common' }/oauth2/v2.0/authorize?client_id=${ config.clientId }&response_type=code&redirect_uri=${ redirectUri }&response_mode=query&scope=${ flatScope }&state=${ OAuth._stateParam(loginStyle, credentialToken, redirectUri) }`;
+  const loginUrl = `https://login.microsoftonline.com/${ config.tenant || 'common' }/oauth2/v2.0/authorize?client_id=${ config.clientId }&response_type=code&redirect_uri=${ redirectUri }&response_mode=query&scope=${ flatScope }&state=${ OAuth._stateParam(loginStyle, credentialToken, options && options.redirectUrl) }`;
 
   OAuth.launchLogin({
     loginService: 'office365',


### PR DESCRIPTION
Hi,

When using loginStyle="redirect", redirecting back doesn't work correctly with current implementation. This login style is the only option for some mobile scenarios.

See for example FB implementation, notice it uses `options && options.redirectUrl` when creating state param:
https://github.com/meteor/meteor/blob/ee32e1328e669fb8ae53c1f0de9e2fa0d9a9cbff/packages/facebook-oauth/facebook_client.js

I did same changes for this package as well.
Would be really nice if this can be merged or fixed some other way, because currently I had to put some quite ugly crutches into the code to get it working with redirect login style.

Thanks!