### PR TITLE
Merge scope with space instead of +

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # office365-oauth
 
-An implementation of the Microsoft Office 365 OAuth flow. See [Meteor Guide](https://guide.meteor.com/accounts.html) for more details.
+An implementation of the Microsoft Office 365 OAuth flow with access and refresh tokens. See [Meteor Guide](https://guide.meteor.com/accounts.html) for more details.

--- a/office365_client.js
+++ b/office365_client.js
@@ -1,5 +1,5 @@
-/*globals Office365, OAuth */
-
+/* globals Office365, OAuth */
+/* eslint-disable */
 Office365 = {};
 
 Office365.requestCredential = function(options, credentialRequestCompleteCallback) {
@@ -8,7 +8,7 @@ Office365.requestCredential = function(options, credentialRequestCompleteCallbac
     options = {};
   }
 
-  const config = ServiceConfiguration.configurations.findOne({service: 'office365'});
+  const config = ServiceConfiguration.configurations.findOne({ service: 'office365' });
   if (!config) {
     credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError());
     return;
@@ -24,13 +24,19 @@ Office365.requestCredential = function(options, credentialRequestCompleteCallbac
   // The Microsoft Office 365 Application not allow the parameter "close" at redirect URLs
   const redirectUri = OAuth._redirectUri('office365', config).replace('?close', '');
 
-  const loginUrl = `https://login.microsoftonline.com/${ config.tenant || 'common' }/oauth2/v2.0/authorize?client_id=${ config.clientId }&response_type=code&redirect_uri=${ redirectUri }&response_mode=query&scope=${ flatScope }&state=${ OAuth._stateParam(loginStyle, credentialToken, redirectUri) }`;
+  const loginUrl = `https://login.microsoftonline.com/${config.tenant || 'common'}/oauth2/v2.0/authorize?client_id=${
+    config.clientId
+  }&response_type=code&redirect_uri=${redirectUri}&response_mode=query&scope=${flatScope}&state=${OAuth._stateParam(
+    loginStyle,
+    credentialToken,
+    redirectUri
+  )}`;
 
   OAuth.launchLogin({
     loginService: 'office365',
     loginStyle,
     loginUrl,
     credentialRequestCompleteCallback,
-    credentialToken
+    credentialToken,
   });
 };

--- a/office365_client.js
+++ b/office365_client.js
@@ -17,7 +17,7 @@ Office365.requestCredential = function(options, credentialRequestCompleteCallbac
   const credentialToken = Random.secret();
 
   const scope = (options && options.requestPermissions) || ['offline_access', 'user.read'];
-  const flatScope = _.map(scope, encodeURIComponent).join('+');
+  const flatScope = encodeURIComponent(scope.join(' '));
 
   const loginStyle = OAuth._loginStyle('office365', config, options);
 

--- a/office365_server.js
+++ b/office365_server.js
@@ -1,67 +1,70 @@
-/*globals Office365, OAuth */
-'use strict';
+/* globals Office365, OAuth */
 
 Office365 = {};
 
 let userAgent = 'Meteor';
-if (Meteor.release) { userAgent += `/${ Meteor.release }`; }
+if (Meteor.release) {
+  userAgent += `/${Meteor.release}`;
+}
 
-const getAccessToken = function(query) {
-  const config = ServiceConfiguration.configurations.findOne({service: 'office365'});
-  if (!config) { throw new ServiceConfiguration.ConfigError(); }
+const getTokenResponse = function(query) {
+  const config = ServiceConfiguration.configurations.findOne({ service: 'office365' });
+  if (!config) {
+    throw new ServiceConfiguration.ConfigError();
+  }
 
   const redirectUri = OAuth._redirectUri('office365', config).replace('?close', '');
 
   let response;
   try {
-    response = HTTP.post(
-      `https://login.microsoftonline.com/${ config.tenant || 'common' }/oauth2/v2.0/token`, {
-        headers: {
-          Accept: 'application/json',
-          'User-Agent': userAgent
-        },
-        params: {
-          grant_type: 'authorization_code',
-          code: query.code,
-          client_id: config.clientId,
-          client_secret: OAuth.openSecret(config.secret),
-          redirect_uri: redirectUri,
-          state: query.state
-        }
-      });
+    response = HTTP.post(`https://login.microsoftonline.com/${config.tenant || 'common'}/oauth2/v2.0/token`, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': userAgent,
+      },
+      params: {
+        grant_type: 'authorization_code',
+        code: query.code,
+        client_id: config.clientId,
+        client_secret: OAuth.openSecret(config.secret),
+        redirect_uri: redirectUri,
+        state: query.state,
+      },
+    });
   } catch (error) {
-    throw _.extend(new Error(`Failed to complete OAuth handshake with Microsoft Office365. ${ error.message }`), {response: error.response});
+    throw _.extend(new Error(`Failed to complete OAuth handshake with Microsoft Office365. ${error.message}`), { response: error.response });
   }
   if (response.data.error) {
-    throw new Error(`Failed to complete OAuth handshake with Microsoft Office365. ${ response.data.error }`);
+    throw new Error(`Failed to complete OAuth handshake with Microsoft Office365. ${response.data.error}`);
   } else {
-    return response.data.access_token;
+    return response.data;
   }
 };
 
 const getIdentity = function(accessToken) {
   try {
-    return HTTP.get(
-      'https://graph.microsoft.com/v1.0/me', {
-        headers: {
-          Authorization: `Bearer ${ accessToken }`,
-          Accept: 'application/json',
-          'User-Agent': userAgent
-        }
-      }).data;
+    return HTTP.get('https://graph.microsoft.com/v1.0/me', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+        'User-Agent': userAgent,
+      },
+    }).data;
   } catch (error) {
-    throw _.extend(new Error(`Failed to fetch identity from Microsoft Office365. ${ error.message }`), {response: error.response});
+    throw _.extend(new Error(`Failed to fetch identity from Microsoft Office365. ${error.message}`), { response: error.response });
   }
 };
 
 OAuth.registerService('office365', 2, null, function(query) {
-  const accessToken = getAccessToken(query);
+  const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } = getTokenResponse(query);
+  const expiresAt = +new Date() + 1000 * expiresIn;
   const identity = getIdentity(accessToken);
-
   return {
     serviceData: {
       id: identity.id,
       accessToken: OAuth.sealSecret(accessToken),
+      refreshToken: OAuth.sealSecret(refreshToken),
+      expiresAt,
       displayName: identity.displayName,
       givenName: identity.givenName,
       surname: identity.surname,
@@ -72,9 +75,9 @@ OAuth.registerService('office365', 2, null, function(query) {
       mobilePhone: identity.mobilePhone,
       businessPhones: identity.businessPhones,
       officeLocation: identity.officeLocation,
-      preferredLanguage: identity.preferredLanguage
+      preferredLanguage: identity.preferredLanguage,
     },
-    options: {profile: {name: identity.givenName}}
+    options: { profile: { name: identity.givenName } },
   };
 });
 

--- a/office365_server.js
+++ b/office365_server.js
@@ -1,67 +1,70 @@
-/*globals Office365, OAuth */
-'use strict';
-
+/* globals Office365, OAuth */
+/* eslint-disable */
 Office365 = {};
 
 let userAgent = 'Meteor';
-if (Meteor.release) { userAgent += `/${ Meteor.release }`; }
+if (Meteor.release) {
+  userAgent += `/${Meteor.release}`;
+}
 
-const getAccessToken = function(query) {
-  const config = ServiceConfiguration.configurations.findOne({service: 'office365'});
-  if (!config) { throw new ServiceConfiguration.ConfigError(); }
+const getTokenResponse = function(query) {
+  const config = ServiceConfiguration.configurations.findOne({ service: 'office365' });
+  if (!config) {
+    throw new ServiceConfiguration.ConfigError();
+  }
 
   const redirectUri = OAuth._redirectUri('office365', config).replace('?close', '');
 
   let response;
   try {
-    response = HTTP.post(
-      `https://login.microsoftonline.com/${ config.tenant || 'common' }/oauth2/v2.0/token`, {
-        headers: {
-          Accept: 'application/json',
-          'User-Agent': userAgent
-        },
-        params: {
-          grant_type: 'authorization_code',
-          code: query.code,
-          client_id: config.clientId,
-          client_secret: OAuth.openSecret(config.secret),
-          redirect_uri: redirectUri,
-          state: query.state
-        }
-      });
+    response = HTTP.post(`https://login.microsoftonline.com/${config.tenant || 'common'}/oauth2/v2.0/token`, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': userAgent,
+      },
+      params: {
+        grant_type: 'authorization_code',
+        code: query.code,
+        client_id: config.clientId,
+        client_secret: OAuth.openSecret(config.secret),
+        redirect_uri: redirectUri,
+        state: query.state,
+      },
+    });
   } catch (error) {
-    throw _.extend(new Error(`Failed to complete OAuth handshake with Microsoft Office365. ${ error.message }`), {response: error.response});
+    throw _.extend(new Error(`Failed to complete OAuth handshake with Microsoft Office365. ${error.message}`), { response: error.response });
   }
   if (response.data.error) {
-    throw new Error(`Failed to complete OAuth handshake with Microsoft Office365. ${ response.data.error }`);
+    throw new Error(`Failed to complete OAuth handshake with Microsoft Office365. ${response.data.error}`);
   } else {
-    return response.data.access_token;
+    return response.data;
   }
 };
 
 const getIdentity = function(accessToken) {
   try {
-    return HTTP.get(
-      'https://graph.microsoft.com/v1.0/me', {
-        headers: {
-          Authorization: `Bearer ${ accessToken }`,
-          Accept: 'application/json',
-          'User-Agent': userAgent
-        }
-      }).data;
+    return HTTP.get('https://graph.microsoft.com/v1.0/me', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+        'User-Agent': userAgent,
+      },
+    }).data;
   } catch (error) {
-    throw _.extend(new Error(`Failed to fetch identity from Microsoft Office365. ${ error.message }`), {response: error.response});
+    throw _.extend(new Error(`Failed to fetch identity from Microsoft Office365. ${error.message}`), { response: error.response });
   }
 };
 
 OAuth.registerService('office365', 2, null, function(query) {
-  const accessToken = getAccessToken(query);
+  const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } = getTokenResponse(query);
+  const expiresAt = +new Date() + 1000 * expiresIn;
   const identity = getIdentity(accessToken);
-
   return {
     serviceData: {
       id: identity.id,
       accessToken: OAuth.sealSecret(accessToken),
+      refreshToken,
+      expiresAt,
       displayName: identity.displayName,
       givenName: identity.givenName,
       surname: identity.surname,
@@ -72,9 +75,9 @@ OAuth.registerService('office365', 2, null, function(query) {
       mobilePhone: identity.mobilePhone,
       businessPhones: identity.businessPhones,
       officeLocation: identity.officeLocation,
-      preferredLanguage: identity.preferredLanguage
+      preferredLanguage: identity.preferredLanguage,
     },
-    options: {profile: {name: identity.givenName}}
+    options: { profile: { name: identity.givenName } },
   };
 });
 

--- a/package.js
+++ b/package.js
@@ -1,9 +1,10 @@
+/* eslint-disable */
 Package.describe({
-  name: 'lindoelio:office365-oauth',
+  name: 'ermlab:office365-oauth',
   version: '0.2.0',
   summary: 'Microsoft Office 365 OAuth flow',
-  git: 'https://github.com/lindoelio/meteor-office365-oauth',
-  documentation: 'README.md'
+  git: 'https://github.com/Ermlab/meteor-office365-oauth.git',
+  documentation: 'README.md',
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
According to the official docs scope is a list of space separated scopes: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow

> A space-separated list of scopes that you want the user to consent to. For the /authorize leg of the request, this can cover multiple resources, allowing your app to get consent for multiple web APIs you want to call.

This fixes this and removes underscore dependency.